### PR TITLE
fix: add .js extensions to ESM imports

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@m4k/client",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "module": "./lib/index.js",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "license": "MIT",
   "description": "Client for m4k server",
   "keywords": [

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,2 +1,2 @@
 export { ProcessedFile } from "@m4k/common";
-export { processAudio, processImage, processVideo } from "./client";
+export { processAudio, processImage, processVideo } from "./client.js";

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@m4k/common",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "module": "./lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "license": "MIT",
   "description": "Common types and utilities for m4k",
   "author": "sv2dev",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -155,4 +155,4 @@ export class ProcessedFile {
   ) {}
 }
 
-export { mimeTypes } from "./mime";
+export { mimeTypes } from "./mime.js";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,16 @@
 {
   "name": "m4k",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "module": "./lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "license": "MIT",
   "description": "Media toolkit for node, bun, and deno",
   "keywords": [

--- a/packages/core/src/audio/audio-processor.ts
+++ b/packages/core/src/audio/audio-processor.ts
@@ -1,7 +1,7 @@
 import { type AudioOptions } from "@m4k/common";
 import { mkdir } from "node:fs/promises";
 import { createQueue } from "tasque";
-import { getExtension, processFfmpeg } from "../util/ffmpeg-processor";
+import { getExtension, processFfmpeg } from "../util/ffmpeg-processor.js";
 
 /**
  * Process an audio file.

--- a/packages/core/src/images/image-processor.ts
+++ b/packages/core/src/images/image-processor.ts
@@ -2,7 +2,7 @@ import { type ImageOptions, ProcessedFile } from "@m4k/common";
 import { createReadStream } from "node:fs";
 import sharp from "sharp";
 import { createQueue } from "tasque";
-import { exhaustAsyncIterableToWritable } from "../util/streams";
+import { exhaustAsyncIterableToWritable } from "../util/streams.js";
 
 export type Format = Required<ImageOptions>["format"];
 export type Fit = Required<Required<ImageOptions>["resize"]>["fit"];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,8 +7,8 @@ export {
   type QueuePosition,
   type VideoOptions
 } from "@m4k/common";
-export { audioQueue, processAudio } from "./audio/audio-processor";
-export { imageQueue, processImage } from "./images/image-processor";
-export { getExtension } from "./util/ffmpeg-processor";
-export { mimeTypes } from "./util/mime";
-export { processVideo, videoQueue } from "./videos/video-processor";
+export { audioQueue, processAudio } from "./audio/audio-processor.js";
+export { imageQueue, processImage } from "./images/image-processor.js";
+export { getExtension } from "./util/ffmpeg-processor.js";
+export { mimeTypes } from "./util/mime.js";
+export { processVideo, videoQueue } from "./videos/video-processor.js";

--- a/packages/core/src/util/ffmpeg-processor.ts
+++ b/packages/core/src/util/ffmpeg-processor.ts
@@ -4,8 +4,8 @@ import { getRandomValues } from "node:crypto";
 import { createWriteStream } from "node:fs";
 import { rm } from "node:fs/promises";
 import { type Tasque } from "tasque";
-import { mimeTypes } from "../util/mime";
-import { exhaustAsyncIterableToWritable } from "../util/streams";
+import { mimeTypes } from "../util/mime.js";
+import { exhaustAsyncIterableToWritable } from "../util/streams.js";
 
 /**
  * Process a video.

--- a/packages/core/src/videos/video-processor.ts
+++ b/packages/core/src/videos/video-processor.ts
@@ -1,7 +1,7 @@
 import { type VideoOptions } from "@m4k/common";
 import { mkdir } from "node:fs/promises";
 import { createQueue } from "tasque";
-import { getExtension, processFfmpeg } from "../util/ffmpeg-processor";
+import { getExtension, processFfmpeg } from "../util/ffmpeg-processor.js";
 /**
  * Process a video.
  * @param input - The input video. Can be a file path, a stream or a blob.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@m4k/server",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "module": "./lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "license": "MIT",
   "description": "Server for m4k",
   "keywords": [

--- a/packages/server/src/audio/process-audio-handler.ts
+++ b/packages/server/src/audio/process-audio-handler.ts
@@ -4,8 +4,8 @@ import { TypeCompiler } from "@sinclair/typebox/compiler";
 import { ProcessedFile, processAudio } from "m4k";
 import { rm } from "node:fs/promises";
 import { basename } from "node:path";
-import { parseOpts } from "../util/request-parsing";
-import { error, queueAndStream } from "../util/response";
+import { parseOpts } from "../util/request-parsing.js";
+import { error, queueAndStream } from "../util/response.js";
 
 const compiledOptionsSchema = TypeCompiler.Compile(audioOptionsSchema);
 

--- a/packages/server/src/images/process-image-handler.ts
+++ b/packages/server/src/images/process-image-handler.ts
@@ -4,9 +4,9 @@ import { Type as T } from "@sinclair/typebox";
 import { TypeCompiler } from "@sinclair/typebox/compiler";
 import { ProcessedFile, processImage } from "m4k";
 import { rm } from "node:fs/promises";
-import { parseOpts } from "../util/request-parsing";
-import { error, queueAndStream } from "../util/response";
-import { numberQueryParamSchema, parse } from "../util/typebox";
+import { parseOpts } from "../util/request-parsing.js";
+import { error, queueAndStream } from "../util/response.js";
+import { numberQueryParamSchema, parse } from "../util/typebox.js";
 
 const compiledOptionsSchema = TypeCompiler.Compile(imageOptionsSchema);
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-import { serveOpts } from "./server";
+import { serveOpts } from "./server.js";
 
 export default {
   ...serveOpts,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,8 +1,8 @@
 import type { ServeOptions, Server } from "bun";
 import { version } from "../package.json";
-import { processAudioHandler } from "./audio/process-audio-handler";
-import { processImageHandler } from "./images/process-image-handler";
-import { processVideoHandler } from "./videos/process-video-handler";
+import { processAudioHandler } from "./audio/process-audio-handler.js";
+import { processImageHandler } from "./images/process-image-handler.js";
+import { processVideoHandler } from "./videos/process-video-handler.js";
 
 export const serveOpts: ServeOptions = {
   maxRequestBodySize: 2 ** 40, // 1TB

--- a/packages/server/src/util/request-parsing.ts
+++ b/packages/server/src/util/request-parsing.ts
@@ -1,6 +1,6 @@
 import type { StaticDecode, TSchema } from "@sinclair/typebox";
 import type { TypeCheck } from "@sinclair/typebox/compiler";
-import { parse } from "./typebox";
+import { parse } from "./typebox.js";
 
 export function parseOpts<TOptions extends TSchema>(
   request: Request,

--- a/packages/server/src/util/response.ts
+++ b/packages/server/src/util/response.ts
@@ -1,6 +1,6 @@
 import { ProcessedFile } from "m4k";
 import { basename } from "node:path";
-import { BOUNDARY, MultipartMixed } from "./multipart-mixed";
+import { BOUNDARY, MultipartMixed } from "./multipart-mixed.js";
 
 export function error(status: number, message: string) {
   return new Response(message, { status });

--- a/packages/server/src/videos/process-video-handler.ts
+++ b/packages/server/src/videos/process-video-handler.ts
@@ -4,8 +4,8 @@ import { TypeCompiler } from "@sinclair/typebox/compiler";
 import { ProcessedFile, processVideo } from "m4k";
 import { rm } from "node:fs/promises";
 import { basename } from "node:path";
-import { parseOpts } from "../util/request-parsing";
-import { error, queueAndStream } from "../util/response";
+import { parseOpts } from "../util/request-parsing.js";
+import { error, queueAndStream } from "../util/response.js";
 
 const compiledOptionsSchema = TypeCompiler.Compile(videoOptionsSchema);
 

--- a/packages/typebox/package.json
+++ b/packages/typebox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m4k/typebox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Add explicit `.js` extensions to all relative imports across all packages, fixing Node.js strict ESM resolution (e.g. Playwright workers)
- Add `exports` field to all package.json files for proper ESM entry point configuration
- Bump patch versions: common 0.2.5, core 0.3.1, client 0.2.5, server 0.2.6, typebox 0.1.1

## Root cause
`moduleResolution: "bundler"` + `verbatimModuleSyntax: true` meant TypeScript accepted extensionless relative imports but passed them through unchanged to the JS output. Node.js strict ESM requires explicit `.js` extensions, causing `ERR_MODULE_NOT_FOUND` for consumers.

## Test plan
- [x] `bun run --filter '*' build` passes
- [x] `bun run --filter '*' test` passes (40 tests)
- [x] `bun run --filter '*' typecheck` passes
- [x] Built output verified to contain `.js` extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented package versions across client, common, core, server, and typebox packages.
  * Added explicit `exports` fields to package configurations for improved module resolution with modern package consumers.
  * Updated import paths to use explicit file extensions for enhanced ESM module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->