### PR TITLE
chore: downgrade bun to 1.2.12

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.12
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     name: Run all tests
     runs-on: ubuntu-latest
-    container: oven/bun:1.3.11
+    container: oven/bun:1.3.12
     steps:
       - uses: actions/checkout@v4
       - run: bun install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.11-slim AS base
+FROM oven/bun:1.3.12-slim AS base
 WORKDIR /app
 
 FROM base AS build

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@m4k/server": "workspace:^",
-        "@types/bun": "^1.3.11",
+        "@types/bun": "^1.3.12",
         "typescript": "^6.0.2",
       },
     },
@@ -55,7 +55,7 @@
       },
       "devDependencies": {
         "@sinclair/typebox": "^0.34.33",
-        "@types/bun": "^1.3.11",
+        "@types/bun": "^1.3.12",
         "typescript": "^6.0.2",
       },
     },
@@ -66,7 +66,7 @@
         "@sinclair/typebox": "^0.34.33",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.11",
+        "@types/bun": "^1.3.12",
         "typescript": "^6.0.2",
       },
     },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@m4k/server": "workspace:^",
-    "@types/bun": "^1.3.11",
+    "@types/bun": "^1.3.12",
     "typescript": "^6.0.2"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.34.33",
-    "@types/bun": "^1.3.11",
+    "@types/bun": "^1.3.12",
     "typescript": "^6.0.2"
   }
 }

--- a/packages/typebox/package.json
+++ b/packages/typebox/package.json
@@ -18,7 +18,7 @@
     "@sinclair/typebox": "^0.34.33"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.11",
+    "@types/bun": "^1.3.12",
     "typescript": "^6.0.2"
   },
   "repository": {


### PR DESCRIPTION
Updates bun from 1.3.11 to 1.2.12 across Dockerfile, workflows, and package dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded Bun runtime version from 1.3.11 to 1.2.12 in CI/CD workflows and Docker configuration
  * Updated corresponding type definition dependencies across packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->