### PR TITLE
chore: bump patch versions for updated dependencies and tests

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m4k/client",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Client for m4k server",
   "keywords": [
     "audio",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m4k/server",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Server for m4k",
   "keywords": [
     "audio",

--- a/packages/typebox/package.json
+++ b/packages/typebox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m4k/typebox",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Bumps patch versions for packages that have received updates:

- @m4k/server: 0.2.7 → 0.2.8 (test additions + dependency updates)
- @m4k/client: 0.2.6 → 0.2.7 (dependency updates)
- @m4k/typebox: 0.1.2 → 0.1.3 (dependency updates)