### PR TITLE
fix: update Docker image FFmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV NODE_ENV=production \
     PORT=3000 \
     HOSTNAME=0.0.0.0 \
     FFMPEG_PATH=/usr/local/bin/ffmpeg
-COPY --from=mwader/static-ffmpeg:7.1.1 /ffmpeg /usr/local/bin/
+COPY --from=mwader/static-ffmpeg:8.1.2 /ffmpeg /usr/local/bin/
 COPY --from=build /app/packages/server/dist/server/app.js /app/app.js
 COPY --from=install /app/node_modules/ /app/node_modules/
 EXPOSE 3000


### PR DESCRIPTION
## Summary

- Update the production M4K Docker image from static FFmpeg 7.1.1 to 8.1.2.
- Update Docker and GitHub Actions to Bun 1.3.14 consistently.
- Bump the affected client, server, and typebox package patch versions and refresh Bun type metadata.

## Verification

- `bun install --frozen-lockfile`
- `bun run build`
- `bun run typecheck`
- `bun run test` (46 passed, 2 skipped)
- `docker build --pull -t m4k-ffmpeg-security-test .`
- Container verification: `ffmpeg version 8.1.2`
